### PR TITLE
Add parse action definition

### DIFF
--- a/wikimedia.go
+++ b/wikimedia.go
@@ -12,6 +12,7 @@ import (
 type ApiResponse struct {
 	Query         ApiQuery         `json:"query"`
 	QueryContinue ApiQueryContinue `json:"query-continue"`
+	Parse         ApiParse         `json:"parse"`
 }
 
 // Strip all HTML tags from the response
@@ -60,6 +61,18 @@ type ApiQueryContinue struct {
 
 type ApiQueryContinueSearch struct {
 	SrOffset int `json:"sroffset"`
+}
+
+type ApiParse struct {
+	PageId     int               `json:"pageid"`
+	Title      string            `json:"title"`
+	Categories []ApiPageCategory `json:"categories"`
+}
+
+type ApiPageCategory struct {
+	SortKey string `json:"sortkey"`
+	Hidden  string `json:"hidden"`
+	Name    string `json:"*"`
 }
 
 func stripHtml(s string) string {

--- a/wikimedia.go
+++ b/wikimedia.go
@@ -67,12 +67,24 @@ type ApiParse struct {
 	PageId     int               `json:"pageid"`
 	Title      string            `json:"title"`
 	Categories []ApiPageCategory `json:"categories"`
+	Sections   []ApiPageSection  `json:"sections"`
 }
 
 type ApiPageCategory struct {
 	SortKey string `json:"sortkey"`
 	Hidden  string `json:"hidden"`
 	Name    string `json:"*"`
+}
+
+type ApiPageSection struct {
+	TOCLevel   int    `json:"toclevel"`
+	Level      string `json:"level"`
+	Line       string `json:"line"`
+	Number     string `json:"number"`
+	Index      string `json:"index"`
+	FromTitle  string `json:"fromtitle"`
+	ByteOffset int    `json:"byteoffset"`
+	Anchor     string `json:"anchor"`
 }
 
 func stripHtml(s string) string {


### PR DESCRIPTION
Hi Patrick,

I came across your project and found good use in the ability to pull content from Wikipedia. One thing I added was a struct to handle the `action=parse` method on the API for retrieving article categories. See here for an [example output](https://en.wikipedia.org/wiki/Special:ApiSandbox#action=parse&format=json&pageid=25039021&prop=categories).

Please let me know if you decide to merge in and would like me to make any changes or not.

Thanks,
Also Patrick.